### PR TITLE
Add constraint check for password

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SetPasswordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetPasswordCommand.java
@@ -17,11 +17,13 @@ public class SetPasswordCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sets a password to protect the address book. "
-            + "Parameters: " + PREFIX_PASSWORD + "PASSWORD\n"
+            + "Parameters: " + PREFIX_PASSWORD + "PASSWORD (no spaces allowed)\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_PASSWORD + "mySecretPass123";
 
     public static final String MESSAGE_SUCCESS = "Password has been set successfully! "
             + "You will be prompted for this password the next time you start the app.";
+
+    public static final String MESSAGE_PASSWORD_CONSTRAINTS = "Password must not contain spaces.";
 
     private final String password;
 

--- a/src/main/java/seedu/address/logic/parser/SetPasswordCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetPasswordCommandParser.java
@@ -24,6 +24,9 @@ public class SetPasswordCommandParser implements Parser<SetPasswordCommand> {
         if (password.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetPasswordCommand.MESSAGE_USAGE));
         }
+        if (password.matches(".*\\s.*")) {
+            throw new ParseException(SetPasswordCommand.MESSAGE_PASSWORD_CONSTRAINTS);
+        }
 
         return new SetPasswordCommand(password);
     }

--- a/src/test/java/seedu/address/logic/parser/SetPasswordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetPasswordCommandParserTest.java
@@ -24,9 +24,21 @@ public class SetPasswordCommandParserTest {
     }
 
     @Test
-    public void parse_passwordWithSpaces_trimmed() {
+    public void parse_leadingTrailingSpacesTrimmed() {
         assertParseSuccess(parser, " " + PREFIX_PASSWORD + "  trimmed  ",
                 new SetPasswordCommand("trimmed"));
+    }
+
+    @Test
+    public void parse_passwordWithInternalSpaces_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_PASSWORD + "12 n/",
+                SetPasswordCommand.MESSAGE_PASSWORD_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_passwordWithTabCharacter_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_PASSWORD + "pass\tword",
+                SetPasswordCommand.MESSAGE_PASSWORD_CONSTRAINTS);
     }
 
     @Test


### PR DESCRIPTION
**Problem**
setpassword pw/12 n/ silently sets the password to "12 n/" instead of rejecting the input. This occurs because ArgumentTokenizer only recognises pw/ as a prefix — any trailing text (including other command prefixes like n/) is captured verbatim as the password value.

**Solution**
Reject passwords that contain whitespace characters after trimming. This prevents accidental inclusion of other prefixes or tokens in the password, and makes the failure explicit rather than silent.

**Changes**
SetPasswordCommand — added MESSAGE_PASSWORD_CONSTRAINTS constant; updated MESSAGE_USAGE to document the no-spaces constraint
SetPasswordCommandParser — added a password.matches(".*\\s.*") guard after the empty check, throwing ParseException with MESSAGE_PASSWORD_CONSTRAINTS on violation
SetPasswordCommandParserTest — renamed parse_passwordWithSpaces_trimmed to parse_leadingTrailingSpacesTrimmed (behaviour unchanged); added parse_passwordWithInternalSpaces_throwsParseException and parse_passwordWithTabCharacter_throwsParseException to cover the bug scenario

**Testing**
Manually verified: setpassword pw/12 n/ now returns "Password must not contain spaces."
Manually verified: setpassword pw/mySecret123 still succeeds