### PR TITLE
fix issues

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -57,6 +57,7 @@ public class MainApp extends Application {
     protected Storage storage;
     protected Model model;
     protected Config config;
+    private boolean passwordCancelled = false;
 
     @Override
     public void init() throws Exception {
@@ -187,7 +188,7 @@ public class MainApp extends Application {
         String passwordHash = model.getPasswordHash();
         if (passwordHash != null) {
             boolean authenticated = promptForPassword(passwordHash);
-            if (!authenticated) {
+            if (!authenticated && !passwordCancelled) {
                 eraseAllData();
             }
         }
@@ -205,6 +206,7 @@ public class MainApp extends Application {
 
             if (result.isEmpty()) {
                 logger.info("Password dialog cancelled. Exiting application.");
+                passwordCancelled = true;
                 Platform.exit();
                 return false;
             }

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -18,6 +18,7 @@ public class GuiSettings implements Serializable {
     private final double windowWidth;
     private final double windowHeight;
     private final Point windowCoordinates;
+    private final boolean isDarkMode;
 
     /**
      * Constructs a {@code GuiSettings} with the default height, width and position.
@@ -26,15 +27,24 @@ public class GuiSettings implements Serializable {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
+        isDarkMode = true;
     }
 
     /**
      * Constructs a {@code GuiSettings} with the specified height, width and position.
      */
     public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
+        this(windowWidth, windowHeight, xPosition, yPosition, true);
+    }
+
+    /**
+     * Constructs a {@code GuiSettings} with the specified height, width, position and colour mode.
+     */
+    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, boolean isDarkMode) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
+        this.isDarkMode = isDarkMode;
     }
 
     public double getWindowWidth() {
@@ -47,6 +57,10 @@ public class GuiSettings implements Serializable {
 
     public Point getWindowCoordinates() {
         return windowCoordinates != null ? new Point(windowCoordinates) : null;
+    }
+
+    public boolean isDarkMode() {
+        return isDarkMode;
     }
 
     @Override
@@ -63,12 +77,13 @@ public class GuiSettings implements Serializable {
         GuiSettings otherGuiSettings = (GuiSettings) other;
         return windowWidth == otherGuiSettings.windowWidth
                 && windowHeight == otherGuiSettings.windowHeight
-                && Objects.equals(windowCoordinates, otherGuiSettings.windowCoordinates);
+                && Objects.equals(windowCoordinates, otherGuiSettings.windowCoordinates)
+                && isDarkMode == otherGuiSettings.isDarkMode;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(windowWidth, windowHeight, windowCoordinates);
+        return Objects.hash(windowWidth, windowHeight, windowCoordinates, isDarkMode);
     }
 
     @Override
@@ -77,6 +92,7 @@ public class GuiSettings implements Serializable {
                 .add("windowWidth", windowWidth)
                 .add("windowHeight", windowHeight)
                 .add("windowCoordinates", windowCoordinates)
+                .add("isDarkMode", isDarkMode)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/autocomplete/CommandAutocomplete.java
+++ b/src/main/java/seedu/address/logic/autocomplete/CommandAutocomplete.java
@@ -27,12 +27,14 @@ import seedu.address.logic.commands.FollowUpCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.commands.PicCommand;
 import seedu.address.logic.commands.PinCommand;
 import seedu.address.logic.commands.RemovePasswordCommand;
 import seedu.address.logic.commands.SetPasswordCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.ToggleColorModeCommand;
+import seedu.address.logic.commands.UnmeetCommand;
 import seedu.address.logic.parser.AddressBookParser;
 
 /**
@@ -123,6 +125,13 @@ public final class CommandAutocomplete {
                 ImportCommand.COMMAND_WORD + " " + PREFIX_FILE_PATH));
 
         list.add(new CommandSuggestion(ListCommand.COMMAND_WORD, "(none)", ListCommand.COMMAND_WORD));
+
+        list.add(new CommandSuggestion(
+                MeetCommand.COMMAND_WORD,
+                "h/START-END [d/DATE] [n/NAME] ...",
+                MeetCommand.COMMAND_WORD + " h/0900-1000"));
+
+        list.add(new CommandSuggestion(UnmeetCommand.COMMAND_WORD, "INDEX", UnmeetCommand.COMMAND_WORD + " 1"));
 
         list.add(new CommandSuggestion(PicCommand.COMMAND_WORD, "INDEX", PicCommand.COMMAND_WORD + " 1"));
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -28,7 +28,7 @@ public class ImportCommand extends StorageCommand {
             + "Parameters: " + PREFIX_FILE_PATH + "FILE_PATH\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_FILE_PATH + "backup.json";
 
-    public static final String MESSAGE_SUCCESS = "Import complete: added %1$d, skipped %2$d (duplicate name).";
+    public static final String MESSAGE_SUCCESS = "Import complete: added %1$d, skipped %2$d (duplicate detected).";
 
     public static final String MESSAGE_FILE_NOT_FOUND = "Import file not found: %1$s";
     public static final String MESSAGE_FILE_NOT_READABLE =

--- a/src/main/java/seedu/address/logic/commands/PinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PinCommand.java
@@ -51,7 +51,7 @@ public class PinCommand extends Command {
         boolean newPinnedStatus = !personToToggle.isPinned();
 
         if (newPinnedStatus) {
-            long currentPinnedCount = lastShownList.stream().filter(Person::isPinned).count();
+            long currentPinnedCount = model.getAddressBook().getPersonList().stream().filter(Person::isPinned).count();
             if (currentPinnedCount >= MAX_PINNED) {
                 throw new CommandException(MESSAGE_MAX_PINS_REACHED);
             }

--- a/src/main/java/seedu/address/model/person/Major.java
+++ b/src/main/java/seedu/address/model/person/Major.java
@@ -9,10 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Major {
 
-    public static final String MESSAGE_CONSTRAINTS = "Majors should only contain alphanumeric characters, "
-            + "and no spaces or special characters allowed.";
-    // alphanumeric and special characters
-    private static final String ALPHANUMERIC_ONLY = "[A-Za-z0-9]+"; // alphanumeric characters only
+    public static final String MESSAGE_CONSTRAINTS = "Majors should only contain alphanumeric characters and spaces.";
+    private static final String ALPHANUMERIC_ONLY = "[A-Za-z0-9][A-Za-z0-9 ]*";
     public static final String VALIDATION_REGEX = ALPHANUMERIC_ONLY;
 
     public final String value;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -237,8 +237,8 @@ public class MainWindow extends UiPart<Stage> {
     private void applyCurrentColorMode() {
         Scene scene = primaryStage.getScene();
         scene.getStylesheets().clear();
-        String themeCSS = isDarkMode ? DARK_THEME_CSS : LIGHT_THEME_CSS;
-        scene.getStylesheets().add(getClass().getResource(themeCSS).toExternalForm());
+        String themeCss = isDarkMode ? DARK_THEME_CSS : LIGHT_THEME_CSS;
+        scene.getStylesheets().add(getClass().getResource(themeCss).toExternalForm());
         scene.getStylesheets().add(getClass().getResource("/view/Extensions.css").toExternalForm());
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -46,6 +46,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private CommandBox commandBox;
+    private ContactDetailPanel contactDetailPanel;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -83,6 +84,7 @@ public class MainWindow extends UiPart<Stage> {
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
+        this.isDarkMode = logic.getGuiSettings().isDarkMode();
 
         setAccelerators();
 
@@ -131,7 +133,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        ContactDetailPanel contactDetailPanel = new ContactDetailPanel();
+        contactDetailPanel = new ContactDetailPanel();
         contactDetailPanel.setOnDelete(index -> {
             try {
                 executeCommand("delete " + index);
@@ -229,6 +231,15 @@ public class MainWindow extends UiPart<Stage> {
 
     void show() {
         primaryStage.show();
+        applyCurrentColorMode();
+    }
+
+    private void applyCurrentColorMode() {
+        Scene scene = primaryStage.getScene();
+        scene.getStylesheets().clear();
+        String themeCSS = isDarkMode ? DARK_THEME_CSS : LIGHT_THEME_CSS;
+        scene.getStylesheets().add(getClass().getResource(themeCSS).toExternalForm());
+        scene.getStylesheets().add(getClass().getResource("/view/Extensions.css").toExternalForm());
     }
 
     /**
@@ -245,6 +256,10 @@ public class MainWindow extends UiPart<Stage> {
                 logger.info("Setting up picture...");
                 logic.setPicture(index, file.getAbsolutePath());
                 resultDisplay.setFeedbackToUser("Profile picture updated for person " + index.getOneBased() + ".");
+                if (contactDetailPanel != null && index.getZeroBased() < logic.getDisplayedPersonList().size()) {
+                    Person updatedPerson = logic.getDisplayedPersonList().get(index.getZeroBased());
+                    contactDetailPanel.updatePerson(updatedPerson, index.getOneBased());
+                }
             } catch (CommandException e) {
                 logger.warning("An error occurred while setting picture!");
                 resultDisplay.setFeedbackToUser("Failed to update picture: " + e.getMessage());
@@ -275,7 +290,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
+                (int) primaryStage.getX(), (int) primaryStage.getY(), isDarkMode);
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();

--- a/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
@@ -1,6 +1,9 @@
 package seedu.address.commons.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,5 +15,46 @@ public class GuiSettingsTest {
                 + ", windowHeight=" + guiSettings.getWindowHeight() + ", windowCoordinates="
                 + guiSettings.getWindowCoordinates() + ", isDarkMode=" + guiSettings.isDarkMode() + "}";
         assertEquals(expected, guiSettings.toString());
+    }
+
+    @Test
+    public void equalsMethod() {
+        GuiSettings defaultSettings = new GuiSettings();
+
+        // same object -> true
+        assertEquals(defaultSettings, defaultSettings);
+
+        // same values -> true
+        GuiSettings sameValues = new GuiSettings(740, 600, 0, 0, true);
+        // default has null coordinates, so compare two explicitly constructed ones
+        GuiSettings a = new GuiSettings(800, 600, 10, 20, true);
+        GuiSettings b = new GuiSettings(800, 600, 10, 20, true);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        // different isDarkMode -> false
+        GuiSettings lightMode = new GuiSettings(800, 600, 10, 20, false);
+        assertNotEquals(a, lightMode);
+
+        // different width -> false
+        GuiSettings differentWidth = new GuiSettings(1024, 600, 10, 20, true);
+        assertNotEquals(a, differentWidth);
+
+        // null -> false
+        assertNotEquals(a, null);
+
+        // different type -> false
+        assertNotEquals(a, "not a GuiSettings");
+    }
+
+    @Test
+    public void isDarkMode_defaultConstructor_returnsTrue() {
+        assertTrue(new GuiSettings().isDarkMode());
+    }
+
+    @Test
+    public void isDarkMode_lightModeConstructor_returnsFalse() {
+        GuiSettings lightSettings = new GuiSettings(800, 600, 0, 0, false);
+        assertFalse(lightSettings.isDarkMode());
     }
 }

--- a/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
@@ -10,7 +10,7 @@ public class GuiSettingsTest {
         GuiSettings guiSettings = new GuiSettings();
         String expected = GuiSettings.class.getCanonicalName() + "{windowWidth=" + guiSettings.getWindowWidth()
                 + ", windowHeight=" + guiSettings.getWindowHeight() + ", windowCoordinates="
-                + guiSettings.getWindowCoordinates() + "}";
+                + guiSettings.getWindowCoordinates() + ", isDarkMode=" + guiSettings.isDarkMode() + "}";
         assertEquals(expected, guiSettings.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/autocomplete/CommandAutocompleteTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/CommandAutocompleteTest.java
@@ -29,7 +29,7 @@ public class CommandAutocompleteTest {
     @Test
     public void getSuggestions_emptyPrefix_allCommandsSorted() {
         List<CommandSuggestion> suggestions = CommandAutocomplete.getSuggestions("");
-        assertEquals(18, suggestions.size());
+        assertEquals(20, suggestions.size());
         List<String> keys = suggestions.stream().map(CommandSuggestion::getMatchKey).collect(Collectors.toList());
         List<String> sorted = keys.stream().sorted(String.CASE_INSENSITIVE_ORDER).collect(Collectors.toList());
         assertEquals(sorted, keys);

--- a/src/test/java/seedu/address/model/person/MajorTest.java
+++ b/src/test/java/seedu/address/model/person/MajorTest.java
@@ -21,7 +21,6 @@ public class MajorTest {
     @Test
     public void constructor_invalidMajor_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new Major(""));
-        assertThrows(IllegalArgumentException.class, () -> new Major("Computer Science"));
         assertThrows(IllegalArgumentException.class, () -> new Major("CS-101"));
     }
 
@@ -34,11 +33,11 @@ public class MajorTest {
 
         assertFalse(Major.isValidMajor(""));
         assertFalse(Major.isValidMajor(" "));
-        assertFalse(Major.isValidMajor("Computer Science"));
         assertFalse(Major.isValidMajor("CS-101"));
 
         assertTrue(Major.isValidMajor("CS"));
         assertTrue(Major.isValidMajor("CS2103T"));
+        assertTrue(Major.isValidMajor("Computer Science"));
     }
 
     /**


### PR DESCRIPTION
- **Color mode persistence (#164)**
  - `GuiSettings`: Added `isDarkMode` field, updated 5-param constructor, and refreshed `equals`/`hashCode`/`toString`.
  - `MainWindow`: Implemented startup reading of `isDarkMode`, added `applyCurrentColorMode()` in `show()`, and ensured persistence in `handleExit()`.
- **Profile picture detail panel refresh (#214)**
  - `MainWindow`: Promoted `contactDetailPanel` to a class field to allow access by `handlePicUpload()`.
  - Updated the panel to call `updatePerson()` immediately after a successful picture upload.
- **Pin limit bypass via filtered view (#176, #215)**
  - `PinCommand`: Modified logic to count pinned persons from the full address book rather than the filtered list, enforcing the 3-pin cap globally.
- **Multi-word major rejection (#180)**
  - `Major`: Updated `ALPHANUMERIC_ONLY` regex to allow spaces (e.g., "Computer Science") and updated `MESSAGE_CONSTRAINTS`.
- **Misleading import success message (#179)**
  - `ImportCommand`: Updated `MESSAGE_SUCCESS` from "duplicate name" to "duplicate detected" to accurately reflect matches in name, phone, or email.
- **Password cancel data erasure (#212)**
  - `MainApp`: Added a `passwordCancelled` flag.
  - Guarded `eraseAllData()` to ensure cancelling the password prompt no longer triggers a data wipe.
- **Missing autocomplete for meet/unmeet (#221)**
  - `CommandAutocomplete`: Imported `MeetCommand` and `UnmeetCommand` and added their respective `CommandSuggestion` entries to the catalog.