### PR TITLE
Update DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,7 +1,9 @@
 ---
 layout: page
-title: Developer Guide
+title: CampusLink Developer Guide
 ---
+# CampusLink Developer Guide
+
 * Table of Contents
 {:toc}
 
@@ -408,6 +410,11 @@ Outcome matrix:
 | Correct password | App opens normally |
 | Cancel dialog | `Platform.exit()` — app closes, no data wiped |
 | 3 wrong entries | `eraseAllData()` — contacts cleared, hash set to null, both files saved |
+
+#### Limitations
+
+* **Local Storage Vulnerability:** Because CampusLink is a local desktop application without a remote authentication server, the password hash is stored locally in the `preferences.json` file. A user with direct file system access can bypass the password protection by opening `preferences.json` and deleting or clearing the `passwordHash` field. This feature is intended to prevent casual snooping when the app is launched rather than secure the data against a malicious user with local file system access.
+
 
 ### Follow-up reminder feature
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,9 +1,11 @@
 ---
 layout: page
-title: User Guide
+title: CampusLink User Guide
 ---
 
 CampusLink is a **desktop app for managing contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, CampusLink can get your contact management tasks done faster than traditional GUI apps.
+
+# CampusLink User Guide
 
 * Table of Contents
 {:toc}


### PR DESCRIPTION
- Issue #186 "Titled as AB3 / Mistitled Developer Guide": The repository's headers and tabs lacked the concrete application name, displaying only "Developer Guide" and leading users back to references to the underlying AddressBook-Level3 framework underneath. I've resolved this by correctly updating the titles in the markdown frontmatter (CampusLink Developer Guide and CampusLink User Guide) and adding an explicit H1 # CampusLink heading to both files' table of content headers to eliminate confusion.
- Issue #192 "setpassword command can be bypassed very easily": This refers to the application relying on storing the SHA-256 hash locally inside [preferences.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Since this system runs purely offline, it's intrinsically vulnerable to file manipulations. I've documented this exact limitation under the Password protection feature > Limitations section inside [DeveloperGuide.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), clarifying that this feature is meant for casual deterrence rather than sophisticated offline security against malicious actors with file access.