### PR TITLE
fix: sorting order changed with followup

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -71,12 +71,12 @@ public class SortCommand extends Command {
             break;
         case RECENT:
             List<Person> unmodifiableList = model.getAddressBook().getPersonList();
-            Map<Person, Integer> indexMap = new HashMap<>();
+            Map<Person, Integer> indexMap = new IdentityHashMap<>();
             int idx = 0;
             for (Person p : unmodifiableList) {
                 indexMap.put(p, idx++);
             }
-            fieldComparator = Comparator.comparingInt(p -> indexMap.getOrDefault(p, -1));
+            fieldComparator = Comparator.comparingInt(p -> indexMap.getOrDefault(p, Integer.MAX_VALUE));
             break;
         default:
             fieldComparator = Comparator.comparing(

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -37,18 +37,26 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        ObservableList<Person> rawPersonList = this.addressBook.getPersonList();
+        filteredPersons = new FilteredList<>(rawPersonList);
         sortedPersons = new SortedList<>(filteredPersons, (p1, p2) -> {
             int pinCompare = Boolean.compare(p2.isPinned(), p1.isPinned());
             if (pinCompare != 0) {
                 return pinCompare;
             }
 
-            // Preserve source-list order for unpinned contacts.
-            // During replacement updates, transient stale objects may not be present in filteredPersons;
-            // push those to the end so existing visible order remains stable.
-            int firstIndex = filteredPersons.indexOf(p1);
-            int secondIndex = filteredPersons.indexOf(p2);
+            // Preserve source-list order for unpinned contacts using reference equality (==)
+            // so that edited person objects (which differ by equals()) are still found correctly.
+            int firstIndex = -1;
+            int secondIndex = -1;
+            for (int i = 0; i < rawPersonList.size(); i++) {
+                if (rawPersonList.get(i) == p1) {
+                    firstIndex = i;
+                }
+                if (rawPersonList.get(i) == p2) {
+                    secondIndex = i;
+                }
+            }
             firstIndex = firstIndex == -1 ? Integer.MAX_VALUE : firstIndex;
             secondIndex = secondIndex == -1 ? Integer.MAX_VALUE : secondIndex;
             return Integer.compare(firstIndex, secondIndex);


### PR DESCRIPTION
The current sorting order comparator and hashmap use doesn't take into account the just edited person object which has the followup added